### PR TITLE
accesibilidad restringida al finalizar plazo en sesiones

### DIFF
--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -8079,17 +8079,25 @@ class SessionManager
 
         $form->addElement('checkbox', 'show_description', null, get_lang('ShowDescription'));
 
+        $options = [
+            SESSION_VISIBLE_READ_ONLY => get_lang('SessionReadOnly'),
+            SESSION_VISIBLE => get_lang('SessionAccessible'),
+            SESSION_INVISIBLE => api_ucfirst(get_lang('SessionNotAccessible')),
+        ];
+
+        $SessionAccesibleConfigOption = api_get_configuration_value('dont_show_SessionAccessible_option');
+        if ($SessionAccesibleConfigOption) {
+            array_splice($options,1,1);
+        }
+
         $visibilityGroup = [];
-        $visibilityGroup[] = $form->createElement(
-            'select',
-            'session_visibility',
-            null,
-            [
-                SESSION_VISIBLE_READ_ONLY => get_lang('SessionReadOnly'),
-                SESSION_VISIBLE => get_lang('SessionAccessible'),
-                SESSION_INVISIBLE => api_ucfirst(get_lang('SessionNotAccessible')),
-            ]
-        );
+            $visibilityGroup[] = $form->createElement(
+                'select',
+                'session_visibility',
+                null,
+               $options
+            );
+
         $form->addGroup(
             $visibilityGroup,
             'visibility_group',

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2134,6 +2134,9 @@ ALTER TABLE gradebook_comment ADD CONSTRAINT FK_C3B70763AD3ED51C FOREIGN KEY (gr
 // Show all student publications (from course and from all sessions) in the work/pending.php page if true. BT#18352
 //$_configuration['assignment_base_course_teacher_access_to_all_session'] = true;
 
+// Removes the SessionAccessible option from advanced settings on a session. 
+//$_configuration['dont_show_SessionAccessible_option'] = true;
+
 // Show a link to the work/pending.php page in my courses (user_portal)
 //$_configuration['my_courses_show_pending_work'] = true;
 


### PR DESCRIPTION
Se ha implementado una solución por configuración al problema con el plazo de las sesiones, ahora no permitirá dejar como accesible una sesión una vez finalizado el plazo, las únicas opciones serán solo lectura y no accesible marcando por defecto no accesible.